### PR TITLE
Improve project structure

### DIFF
--- a/downloader/data-downloader.go
+++ b/downloader/data-downloader.go
@@ -1,4 +1,4 @@
-package dataDownloader
+package downloader
 
 import (
 	"bufio"
@@ -400,7 +400,7 @@ MainLoop:
 }
 
 func version() {
-	fmt.Fprintln(os.Stderr, "Audisto Data Downloader, Version " + VERSION)
+	fmt.Fprintln(os.Stderr, "Audisto Data Downloader, Version "+VERSION)
 }
 
 func usage() {

--- a/downloader/data-downloader_test.go
+++ b/downloader/data-downloader_test.go
@@ -1,8 +1,9 @@
-package dataDownloader
+package downloader
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestChs(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -1,10 +1,11 @@
 package main
 
-import "./package"
+import "github.com/audisto/data-downloader/downloader"
 
 func init() {
-	dataDownloader.Initialize()
+	downloader.Initialize()
 }
+
 func main() {
-	dataDownloader.Run()
+	downloader.Run()
 }


### PR DESCRIPTION
* Use real import paths instead of relative imports. Relative imports are highly discouraged in the go community.

* Rename package directory to downloader. package is the Go keyworld, no need to add more confusion.

* To reflect the directory change the package under downloader directory was renamed to downloader